### PR TITLE
Update racing page with NASA links and featured car

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,3 @@
-/* Existing styles */
 body {
     margin: 0;
     font-family: Arial, sans-serif;
@@ -6,7 +5,66 @@ body {
     background-color: #f0f0f0;
 }
 
-/* Add new styles for featured car section */
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+header {
+    background-color: #333;
+    color: white;
+    padding: 1rem;
+    text-align: center;
+    border-radius: 5px;
+    margin-bottom: 2rem;
+}
+
+.nav-links {
+    list-style: none;
+    padding: 0;
+    margin: 1rem 0;
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+}
+
+.nav-links a {
+    color: white;
+    text-decoration: none;
+    padding: 0.5rem 1rem;
+    border-radius: 3px;
+    transition: background-color 0.3s;
+}
+
+.nav-links a:hover {
+    background-color: #555;
+}
+
+main {
+    background-color: white;
+    padding: 20px;
+    margin: 20px 0;
+    border-radius: 5px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
+
+section {
+    margin-bottom: 2rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid #eee;
+}
+
+section:last-child {
+    border-bottom: none;
+}
+
+h2 {
+    color: #333;
+    margin-bottom: 1rem;
+}
+
+/* Featured Car Section */
 .featured-car {
     margin-bottom: 2rem;
 }
@@ -29,7 +87,7 @@ body {
     margin-top: 0.5rem;
 }
 
-/* NASA Links section */
+/* NASA Links Section */
 .nasa-links {
     margin-bottom: 2rem;
 }
@@ -41,6 +99,14 @@ body {
 
 .important-links li {
     margin-bottom: 1rem;
+    padding: 1rem;
+    background-color: #f9f9f9;
+    border-radius: 5px;
+    transition: background-color 0.3s;
+}
+
+.important-links li:hover {
+    background-color: #f0f0f0;
 }
 
 .important-links a {
@@ -53,4 +119,38 @@ body {
     text-decoration: underline;
 }
 
-/* Rest of existing styles remain the same */
+/* Racing Categories */
+.category {
+    background-color: #f9f9f9;
+    padding: 1rem;
+    border-radius: 5px;
+    margin-bottom: 1rem;
+}
+
+.category h3 {
+    color: #333;
+    margin-bottom: 0.5rem;
+}
+
+.category ul {
+    list-style: disc;
+    margin-left: 1.5rem;
+}
+
+/* Racing Tips */
+.racing-tips ul {
+    list-style: none;
+    padding: 0;
+}
+
+.racing-tips li {
+    padding: 0.5rem 0;
+    border-bottom: 1px solid #eee;
+}
+
+footer {
+    text-align: center;
+    color: #666;
+    padding: 10px;
+    margin-top: 2rem;
+}


### PR DESCRIPTION
This PR updates the racing page with:

1. Added NASA SoCal links:
   - Link to NASA SoCal official website
   - Link to Speedhive standings

2. Added featured car section:
   - G37 endurance car image
   - Image caption and styling

3. Updated styling:
   - Responsive image handling
   - Improved link styling
   - Better section organization
   - Enhanced visual hierarchy

4. Updated racing categories to focus on NASA racing

Please review and merge if everything looks good.